### PR TITLE
Updates for 2020 situation

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -10,25 +10,25 @@ params:
   # Conference info
   Name: "R / Pharma"
   Description: "Using R to bring medicines to patients"
-  Date: "August 21, 22, and 23, 2019"
+  Date: "TBD"
   #Price: "Registration closes April 1st" # If your event is free, just comment this line
-  Venue: "Harvard University"
+  #Venue: "Harvard University"
   Address: "Harvard University, CGIS South, Cambridge Street, Cambridge, MA, USA"
-  City:  "Cambridge"
-  State: "MA"
+  #City:  "Cambridge"
+  #State: "MA"
   Images: ["/img/badge.jpg"]
 
   # Active sections on the website to deactivate comment out with '#'
   # you can also change order here and it will reflect on page
   Sections:
     - about
-    - keynotes
-    - workshops
-    - schedule
+    #- keynotes
+    #- workshops
+    #- schedule
     #- call4papers
-    - location
+    #- location
     #- hotel
-    - programs
+    #- programs
     #- grants
     #- sponsors
     #- governance

--- a/themes/hugo-conference/layouts/partials/about.html
+++ b/themes/hugo-conference/layouts/partials/about.html
@@ -1,37 +1,11 @@
 <h2 class="section-title">{{ .titles.about }}</h2>
 
-<p itemprop="description">The second annual R/Pharma conference will take place August 21, 22, and 23, 2019
-  at Harvard University, Cambridge, Massachusetts, USA.</p>
-
 <blockquote style="border: 2px solid #f70d1a; padding: 10px; background-color: #ffe8e7;">
 <p>
-Please note that R/Pharma 2019 is now full.</br></br>
+<b>Important Update for 2020</b></br></br>
 
-Thank you for the interest to attend R/Pharma 2019.</br></br>
-
-R/Pharma is deliberately a smaller event in terms of attendance in order to foster a more personal experience for attendees.
-Moreover, R/Pharma is a participant-driven gathering where the attendees are involved in running and
-organizing the meeting -  a Contributor Attended Gathering. Our goal is to bring together the pharma
-community around open source R and attendance is driven by participation.</br></br>
-
-Please use the chat button (blue circle in lower left of screen) to let us know if you would like to be added to the wait-list.</p>
+Due to the COVID-19 pandemic, the R/Pharma conference for 2020 will be an online/virtual conference.  The R/Pharma organizing committee is finalizing a new date and the logistics regarding calls for proposals and the infrastructure on hosting the conference.  Please stay tuned for further updates on the conference via this web site and the R/Pharma twitter account.
 </blockquote>
-
-
-<p>Based on feedback, we have devoted a 3rd day to the conference agenda focused
-  completely on R/Pharma workshops for attendees. More info will be available soon.
-  </p>
-
-<p>By design, R / Pharma is deliberately a smaller conference in terms of
-  attendance in order to encourage maximum opportunities for direct interaction
-  with speakers. The location will be the Center for Government and International
-  Studies in the Tsai Auditorium at Harvard University and capped at 150 attendees.
-  As of now, we are planning to make the gathering a free event. Invitations are firstly based on committee membership and advisory support,
-  speaker acceptance, academic/student and diversity attendance. </p>
-
-<p>Our entire event is a community-lead effort and 100% volunteer run.
-  The event is vendor neutral and very much an academic conference.
-  Harvard has been very helpful in hosting the event.</p>
 
 <p>R/Pharma is an ISC working group (<a href="https://www.r-consortium.org/projects/isc-
 working-groups">www.r-consortium.org/projects/isc-working-groups</a>) under the R Consortium. The conference is envisioned as a relatively small, scientifically &amp;
@@ -49,91 +23,3 @@ practitioners to key R developers to leading academics, pre-conference workshops
 presentations as well as a number of shorter, highly-energetic lightning talks.</p>
 
 <p>R/Pharma is dedicated to providing a harassment-free conference experience for everyone regardless of gender, sexual orientation, disability or any feature that distinguishes human beings. For more information, please see the <a href="https://wiki.r-consortium.org/view/R_Consortium_and_the_R_Community_Code_of_Conduct">R Consortium code of conduct</a>.</p>
-
-<h3>2019 Organising Committee</h3>
-
-<p>The organising committee focuses on the logistics of running this conference.
-  The content of this conference is shaped by dozens of Pharma industry colleagues in a community effort, led by John Sims and
-  Bella Feng.</p>
-
-<div class="cui-embed" data-cui-uid="zy7oAM" data-cui-avatar="https://images.typeform.com/images/pFJDQYjJjQAW" data-cui-mode="pill" data-cui-pill-button-color="#0000FF"></div><script src="https://public-assets.typeform.com/confab/embed.js" async></script>
-
-<style type="text/css">
-.tg td{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;}
-.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;}
-th, td {
- border-bottom: 1px solid #ddd;
-}
-.tg .tg-0lax{text-align:left;vertical-align:top}
-</style>
-<table class="tg">
-  <tr>
-    <td class="tg-0lax">Harvey Lieberman</td>
-    <td class="tg-0lax">Sanofi</td>
-  </tr>
-  <tr>
-    <td class="tg-0lax">Phil Bowsher</td>
-    <td class="tg-0lax">RStudio</td>
-  </tr>
-  <tr>
-    <td class="tg-0lax">James Black</td>
-    <td class="tg-0lax">Roche/Genentech</td>
-  </tr>
-  <tr>
-    <td class="tg-0lax">Edward Lauzier</td>
-    <td class="tg-0lax">Merck</td>
-  </tr>
-  <tr>
-    <td class="tg-0lax">Elena Rantou</td>
-    <td class="tg-0lax">FDA</td>
-  </tr>
-  <tr>
-    <td class="tg-0lax">Melvin Munsaka</td>
-    <td class="tg-0lax">AbbVie</td>
-  </tr>
-  <tr>
-    <td class="tg-0lax">Eric Nantz</td>
-    <td class="tg-0lax">Eli Lilly</td>
-  </tr>
-  <tr>
-    <td class="tg-0lax">Paul Schuette</td>
-    <td class="tg-0lax">FDA</td>
-  </tr>
-  <tr>
-    <td class="tg-0lax">Michael Blanks</td>
-    <td class="tg-0lax">Beigene</td>
-  </tr>
-  <tr>
-    <td class="tg-0lax">Min Lee</td>
-    <td class="tg-0lax">Amgen</td>
-  </tr>
-  <tr>
-  <tr>
-    <td class="tg-0lax">Reinhold Koch</td>
-    <td class="tg-0lax">Roche/Genentech</td>
-  </tr>
-  <tr>
-    <td class="tg-0lax">Paulo Bargo</td>
-    <td class="tg-0lax">Janssen</td>
-  </tr>
-  <tr>
-    <td class="tg-0lax">Volha Tryputsen</td>
-    <td class="tg-0lax">Janssen</td>
-  </tr>
-  <tr>
-    <td class="tg-0lax">Elizabeth Hess</td>
-    <td class="tg-0lax">IQSS Harvard University</td>
-  </tr>
-  <tr>
-    <td class="tg-0lax">John Sims</td>
-    <td class="tg-0lax">Pfizer (& Program Committee link)</td>
-  </tr>
-  <tr>
-    <td class="tg-0lax">Bella Fang</td>
-    <td class="tg-0lax">KitePharma, A Gilead Company (& Program Committee link)</td>
-  </tr>
-  <tr>
-    <td class="tg-0lax">Michael Lawrence</td>
-    <td class="tg-0lax">Roche/Genentech (& R Foundation link)</td>
-  </tr>
-</table>

--- a/themes/hugo-conference/layouts/partials/header.html
+++ b/themes/hugo-conference/layouts/partials/header.html
@@ -12,7 +12,7 @@
     </h1>
     -->
     <img src = "img/logotext_small.png" alt="R/Pharma logo">
-    <h2 class="tagline">{{ .date }}, {{ .venue }}, {{ .city }}</h2>
+    <h2 class="tagline">{{ .date }}</h2>
 
     <div class="call-action-area">
       {{ with .price }}


### PR DESCRIPTION
This PR updates the main page to remove 2019 information and add a clarifying statement regarding the 2020 plans.